### PR TITLE
fix: alias redis import

### DIFF
--- a/internal/db/redis.go
+++ b/internal/db/redis.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	"github.com/redis/go-redis/v9"
+	redis "github.com/redis/go-redis/v9"
 )
 
 // NewRedisClient creates a new Redis client.


### PR DESCRIPTION
## Summary
- alias redis import to `redis`

## Testing
- `go mod tidy`
- `go test ./...` *(failed: no output, manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f47e044832d8c1f249f1278706a