### PR TITLE
ci: prepare go modules for lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
     - name: Vet
       run: go vet ./...
 
+    - name: Set up Go for golangci-lint
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.24
+
+    - run: go mod tidy && go mod download
+
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:


### PR DESCRIPTION
## Summary
- set up Go 1.24 and download modules before running golangci-lint

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f3e8224832d874a5df0e573e017