### PR TITLE
Explicit redis_rate import in rate limit middleware

### DIFF
--- a/internal/transport/http/middleware/rate_limit.go
+++ b/internal/transport/http/middleware/rate_limit.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/go-redis/redis_rate/v10"
+	redis_rate "github.com/go-redis/redis_rate/v10"
 	"github.com/jules-labs/go-api-prod-template/internal/transport/http/response"
 )
 


### PR DESCRIPTION
## Summary
- alias redis_rate import in rate limit middleware
- run `go mod tidy`

## Testing
- `go test ./internal/transport/http/...` *(fails: test process hung; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f447510832d94031c88fd5e6013