### PR TITLE
Explicit chi and redis_rate aliases in router

### DIFF
--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
+	chi "github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/go-redis/redis_rate/v10"
+	redis_rate "github.com/go-redis/redis_rate/v10"
 	"github.com/jules-labs/go-api-prod-template/internal/config"
 	"github.com/jules-labs/go-api-prod-template/internal/repo"
 	"github.com/jules-labs/go-api-prod-template/internal/service"


### PR DESCRIPTION
## Summary
- alias chi and redis_rate imports in HTTP router

## Testing
- `go test ./...` *(fails: test panicked: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f464954832da0cae6db709cab9a