### PR TITLE
Alias JWT import in middleware

### DIFF
--- a/internal/transport/http/middleware/auth_jwt.go
+++ b/internal/transport/http/middleware/auth_jwt.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golang-jwt/jwt/v5"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/jules-labs/go-api-prod-template/internal/repo"
 	"github.com/jules-labs/go-api-prod-template/internal/transport/http/response"
 )


### PR DESCRIPTION
## Summary
- alias the jwt library import

## Testing
- `go mod tidy`
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f43d560832daeda65cd980142f8