### PR TITLE
Alias resty import in third-party client

### DIFF
--- a/internal/clients/thirdparty.go
+++ b/internal/clients/thirdparty.go
@@ -6,14 +6,14 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-resty/resty/v2"
+	resty "github.com/go-resty/resty/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/rs/zerolog"
 	"github.com/sony/gobreaker"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"github.com/rs/zerolog"
 )
 
 var (


### PR DESCRIPTION
## Summary
- explicitly alias resty import in third-party client
- run `go mod tidy`

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f42b254832db71307946f0f3414