### PR TITLE
Alias validator and redis imports in HTTP handlers

### DIFF
--- a/internal/transport/http/handlers.go
+++ b/internal/transport/http/handlers.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-playground/validator/v10"
+	validator "github.com/go-playground/validator/v10"
 	"github.com/jules-labs/go-api-prod-template/internal/service"
 	app_middleware "github.com/jules-labs/go-api-prod-template/internal/transport/http/middleware"
 	"github.com/jules-labs/go-api-prod-template/internal/transport/http/response"
-	"github.com/redis/go-redis/v9"
+	redis "github.com/redis/go-redis/v9"
 )
 
 var validate = validator.New()


### PR DESCRIPTION
## Summary
- alias validator and redis packages in HTTP handlers

## Testing
- `make lint` *(fails: internal/clients/thirdparty_test.go:20:10: Error return value of `w.Write` is not checked (errcheck))*

------
https://chatgpt.com/codex/tasks/task_e_689c216a0e4c832dac9094dab869d942