### PR TITLE
Alias redis client import

### DIFF
--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jules-labs/go-api-prod-template/internal/service"
 	app_middleware "github.com/jules-labs/go-api-prod-template/internal/transport/http/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/redis/go-redis/v9"
+	redis "github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 )
 


### PR DESCRIPTION
## Summary
- alias go-redis/v9 import as redis to keep redis.Client references consistent

## Testing
- `go test ./...` *(fails: command hung, possibly due to missing private module credentials)*

------
https://chatgpt.com/codex/tasks/task_e_689c216a2870832db6ebabf877df8752