### PR TITLE
refactor: use testify assert and require in integration test

### DIFF
--- a/cmd/api/main_integration_test.go
+++ b/cmd/api/main_integration_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/jules-labs/go-api-prod-template/internal/service"
 	httptransport "github.com/jules-labs/go-api-prod-template/internal/transport/http"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	testcontainers "github.com/testcontainers/testcontainers-go"
 	postgres "github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -45,21 +47,21 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		postgres.WithUsername("user"),
 		postgres.WithPassword("password"),
 	)
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 	s.pgDSN, err = s.pgContainer.ConnectionString(ctx, "sslmode=disable")
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 
 	// Run migrations
 	m, err := migrate.New("file://../../migrations", s.pgDSN)
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 	err = m.Up()
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 
 	// Start Redis
 	s.rdContainer, err = redis.RunContainer(ctx, testcontainers.WithImage("redis:7-alpine"))
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 	s.redisAddr, err = s.rdContainer.Endpoint(ctx, "")
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 
 	// Create app
 	cfg := config.Config{
@@ -67,7 +69,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		RedisAddr: s.redisAddr,
 	}
 	dbConn, err := sql.Open("pgx", cfg.PGDSN)
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 
 	s.queries = db.New(dbConn)
 	redisClient := db.NewRedisClient(cfg.RedisAddr, "", 0)
@@ -85,20 +87,20 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 func (s *IntegrationTestSuite) TearDownSuite() {
 	s.server.Close()
-	s.Require().NoError(s.pgContainer.Terminate(context.Background()))
-	s.Require().NoError(s.rdContainer.Terminate(context.Background()))
+	require.NoError(s.T(), s.pgContainer.Terminate(context.Background()))
+	require.NoError(s.T(), s.rdContainer.Terminate(context.Background()))
 }
 
 func (s *IntegrationTestSuite) TestProfileEndpoint_APIKeyAuth() {
 	// 1. Create a user
 	user, err := s.queries.CreateUser(context.Background(), db.CreateUserParams{Email: "test@example.com", Plan: "free"})
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 
 	// 2. Create an API key
 	apiKeyRepo := repo.NewAPIKeyRepository(s.queries)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo)
 	plainTextKey, _, err := apiKeySvc.CreateAPIKey(context.Background(), user.ID, "test key", 100)
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 
 	// 3. Make request
 	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/v1/profile", s.server.URL), nil)
@@ -106,11 +108,11 @@ func (s *IntegrationTestSuite) TestProfileEndpoint_APIKeyAuth() {
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	s.Require().NoError(err)
+	require.NoError(s.T(), err)
 	defer resp.Body.Close()
 
 	// 4. Assert
-	s.Equal(http.StatusOK, resp.StatusCode)
+	assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
 }
 
 func TestIntegration(t *testing.T) {


### PR DESCRIPTION
## Summary
- use testify's `require` and `assert` instead of suite helpers in `main_integration_test.go`

## Testing
- `golangci-lint run --timeout 5m` *(fails: error return value of `dbConn.Close` is not checked, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689c216b2e64832da46f64ad6b33db85