### PR TITLE
refactor: use suite assertions in integration test

### DIFF
--- a/cmd/api/main_integration_test.go
+++ b/cmd/api/main_integration_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/jules-labs/go-api-prod-template/internal/service"
 	httptransport "github.com/jules-labs/go-api-prod-template/internal/transport/http"
 	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	postgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	redis "github.com/testcontainers/testcontainers-go/modules/redis"
@@ -46,21 +44,21 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		postgres.WithUsername("user"),
 		postgres.WithPassword("password"),
 	)
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 	s.pgDSN, err = s.pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 
 	// Run migrations
 	m, err := migrate.New("file://../../migrations", s.pgDSN)
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 	err = m.Up()
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 
 	// Start Redis
 	s.rdContainer, err = redis.Run(ctx, "redis:7-alpine")
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 	s.redisAddr, err = s.rdContainer.Endpoint(ctx, "")
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 
 	// Create app
 	cfg := config.Config{
@@ -68,7 +66,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		RedisAddr: s.redisAddr,
 	}
 	dbConn, err := sql.Open("pgx", cfg.PGDSN)
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 
 	s.queries = db.New(dbConn)
 	redisClient := db.NewRedisClient(cfg.RedisAddr, "", 0)
@@ -86,20 +84,20 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 func (s *IntegrationTestSuite) TearDownSuite() {
 	s.server.Close()
-	require.NoError(s.T(), s.pgContainer.Terminate(context.Background()))
-	require.NoError(s.T(), s.rdContainer.Terminate(context.Background()))
+	s.Require().NoError(s.pgContainer.Terminate(context.Background()))
+	s.Require().NoError(s.rdContainer.Terminate(context.Background()))
 }
 
 func (s *IntegrationTestSuite) TestProfileEndpoint_APIKeyAuth() {
 	// 1. Create a user
 	user, err := s.queries.CreateUser(context.Background(), db.CreateUserParams{Email: "test@example.com", Plan: "free"})
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 
 	// 2. Create an API key
 	apiKeyRepo := repo.NewAPIKeyRepository(s.queries)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo)
 	plainTextKey, _, err := apiKeySvc.CreateAPIKey(context.Background(), user.ID, "test key", 100)
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 
 	// 3. Make request
 	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/v1/profile", s.server.URL), nil)
@@ -107,13 +105,13 @@ func (s *IntegrationTestSuite) TestProfileEndpoint_APIKeyAuth() {
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
 	// 4. Assert
-	assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+	s.Assert().Equal(http.StatusOK, resp.StatusCode)
 }
 
 func TestIntegration(t *testing.T) {


### PR DESCRIPTION
## Summary
- use test suite's `Require`/`Assert` helpers instead of calling `s.T()` in integration tests

## Testing
- `golangci-lint run`
- `go test ./... -short`


------
https://chatgpt.com/codex/tasks/task_e_689c5c100318832da2ec2cf78582e94e