### PR TITLE
fix: run CI with supported Go toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.23'
         cache: true
 
     - name: Install sqlc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jules-labs/go-api-prod-template
 
-go 1.24.3
+go 1.23
 
 require (
 	github.com/go-chi/chi/v5 v5.2.2


### PR DESCRIPTION
## Summary
- target Go 1.23 in go.mod
- use Go 1.23 in CI workflow to avoid golangci-lint import errors

## Testing
- `gofmt -l .`
- `go vet ./...` *(fails: go mod tidy required due to missing Go 1.23 toolchain)*
- `golangci-lint run` *(fails: context loading failed, needs go mod tidy)*
- `go test -v ./...`
- `go build -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c9c7b363c832da3af7a3fbd0e1f09