### PR TITLE
Move rate limiter before v1 routes

### DIFF
--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -57,6 +57,10 @@ func NewRouter(
 
 	// API v1
 	r.Route("/v1", func(v1 chi.Router) {
+		// Rate limiting middleware
+		limiter := redis_rate.NewLimiter(redisClient)
+		v1.Use(app_middleware.PlanAwareRateLimiter(limiter, cfg.RateLimitRPMDefault))
+
 		// Auth
 		jwtAuth := app_middleware.JWTAuth(cfg.JWTSecretFile, userRepo)
 		v1.Route("/auth", func(auth chi.Router) {
@@ -68,10 +72,6 @@ func NewRouter(
 				g.Get("/me", MeHandler(profileSvc))
 			})
 		})
-
-		// Rate limiting middleware
-		limiter := redis_rate.NewLimiter(redisClient)
-		v1.Use(app_middleware.PlanAwareRateLimiter(limiter, cfg.RateLimitRPMDefault))
 
 		// Protected API
 		v1.Group(func(protected chi.Router) {


### PR DESCRIPTION
## Summary
- ensure rate limiter middleware is registered before v1 routes

## Testing
- `go run cmd/api/main.go` *(fails: failed to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_689dca183ce8832dbf89d9986518d964