### PR TITLE
Add API key listing and deletion endpoints

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -20,10 +20,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
   /apikeys:
+    get:
+      summary: List API keys
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: A list of API keys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/APIKey'
     post:
       summary: Create a new API key
       security:
-        - ApiKeyAuth: []
         - BearerAuth: []
       requestBody:
         required: true
@@ -34,6 +46,21 @@ paths:
       responses:
         '201':
           description: API key created
+  /apikeys/{id}:
+    delete:
+      summary: Delete an API key
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: API key deleted
   /vendor/ping:
     get:
       summary: Ping a vendor service
@@ -123,6 +150,21 @@ components:
           type: string
           format: date-time
         updated_at:
+          type: string
+          format: date-time
+    APIKey:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        label:
+          type: string
+        active:
+          type: boolean
+        rate_rpm:
+          type: integer
+        created_at:
           type: string
           format: date-time
     APIKeyRequest:

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -10,13 +10,14 @@ import (
 )
 
 type ApiKey struct {
-	ID        int64          `json:"id"`
-	UserID    int64          `json:"user_id"`
-	KeyHash   []byte         `json:"key_hash"`
-	Label     sql.NullString `json:"label"`
-	Active    bool           `json:"active"`
-	RateRpm   int32          `json:"rate_rpm"`
-	CreatedAt time.Time      `json:"created_at"`
+	ID         int64          `json:"id"`
+	UserID     int64          `json:"user_id"`
+	KeyHash    []byte         `json:"key_hash"`
+	Label      sql.NullString `json:"label"`
+	Active     bool           `json:"active"`
+	RateRpm    int32          `json:"rate_rpm"`
+	LastUsedAt sql.NullTime   `json:"last_used_at"`
+	CreatedAt  time.Time      `json:"created_at"`
 }
 
 type User struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -11,11 +11,13 @@ import (
 type Querier interface {
 	CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (CreateAPIKeyRow, error)
 	CreateUser(ctx context.Context, arg CreateUserParams) (CreateUserRow, error)
+	DeleteAPIKey(ctx context.Context, arg DeleteAPIKeyParams) error
 	GetAPIKeyByHash(ctx context.Context, keyHash []byte) (GetAPIKeyByHashRow, error)
 	GetUserByEmail(ctx context.Context, email string) (GetUserByEmailRow, error)
 	GetUserByEmailForLogin(ctx context.Context, email string) (GetUserByEmailForLoginRow, error)
 	// keyset pagination
 	GetUserByID(ctx context.Context, id int64) (GetUserByIDRow, error)
+	ListAPIKeysByUser(ctx context.Context, userID int64) ([]ListAPIKeysByUserRow, error)
 	ListUsersPaged(ctx context.Context, arg ListUsersPagedParams) ([]ListUsersPagedRow, error)
 }
 

--- a/internal/db/queries/apikeys.sql
+++ b/internal/db/queries/apikeys.sql
@@ -5,3 +5,9 @@ SELECT id, user_id, key_hash, active, rate_rpm FROM api_keys WHERE key_hash = $1
 INSERT INTO api_keys (user_id, key_hash, label, rate_rpm)
 VALUES ($1, $2, $3, $4)
 RETURNING id, user_id, label, active, rate_rpm, created_at;
+
+-- name: ListAPIKeysByUser :many
+SELECT id, label, active, rate_rpm, created_at FROM api_keys WHERE user_id = $1;
+
+-- name: DeleteAPIKey :exec
+UPDATE api_keys SET active = FALSE WHERE user_id = $1 AND id = $2;

--- a/internal/repo/apikey_repo.go
+++ b/internal/repo/apikey_repo.go
@@ -10,6 +10,8 @@ import (
 type APIKeyRepository interface {
 	GetAPIKeyByHash(ctx context.Context, keyHash []byte) (db.GetAPIKeyByHashRow, error)
 	CreateAPIKey(ctx context.Context, arg db.CreateAPIKeyParams) (db.CreateAPIKeyRow, error)
+	ListAPIKeysByUser(ctx context.Context, userID int64) ([]db.ListAPIKeysByUserRow, error)
+	DeleteAPIKey(ctx context.Context, userID, keyID int64) error
 }
 
 type postgresAPIKeyRepository struct {
@@ -28,6 +30,18 @@ func (r *postgresAPIKeyRepository) GetAPIKeyByHash(ctx context.Context, keyHash 
 
 func (r *postgresAPIKeyRepository) CreateAPIKey(ctx context.Context, arg db.CreateAPIKeyParams) (db.CreateAPIKeyRow, error) {
 	return r.q.CreateAPIKey(ctx, arg)
+}
+
+func (r *postgresAPIKeyRepository) ListAPIKeysByUser(ctx context.Context, userID int64) ([]db.ListAPIKeysByUserRow, error) {
+	return r.q.ListAPIKeysByUser(ctx, userID)
+}
+
+func (r *postgresAPIKeyRepository) DeleteAPIKey(ctx context.Context, userID, keyID int64) error {
+	params := db.DeleteAPIKeyParams{
+		UserID: userID,
+		ID:     keyID,
+	}
+	return r.q.DeleteAPIKey(ctx, params)
 }
 
 // HashAPIKey creates a SHA256 hash of an API key.

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -13,6 +13,8 @@ import (
 
 type APIKeyService interface {
 	CreateAPIKey(ctx context.Context, userID int64, label string, rateRPM int) (string, db.CreateAPIKeyRow, error)
+	ListAPIKeys(ctx context.Context, userID int64) ([]db.ListAPIKeysByUserRow, error)
+	DeleteAPIKey(ctx context.Context, userID, keyID int64) error
 }
 
 type apiKeyService struct {
@@ -46,6 +48,14 @@ func (s *apiKeyService) CreateAPIKey(ctx context.Context, userID int64, label st
 	}
 
 	return plaintextKey, createdKey, nil
+}
+
+func (s *apiKeyService) ListAPIKeys(ctx context.Context, userID int64) ([]db.ListAPIKeysByUserRow, error) {
+	return s.apiKeyRepo.ListAPIKeysByUser(ctx, userID)
+}
+
+func (s *apiKeyService) DeleteAPIKey(ctx context.Context, userID, keyID int64) error {
+	return s.apiKeyRepo.DeleteAPIKey(ctx, userID, keyID)
 }
 
 func generateRandomKey(length int) (string, error) {

--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -74,8 +74,14 @@ func NewRouter(
 			protected.Use(app_middleware.AuthEither(apiKeyAuth, jwtAuth))
 
 			protected.Get("/profile", ProfileHandler(profileSvc))
-			protected.Post("/apikeys", APIKeyHandler(apiKeySvc))
 			protected.Get("/vendor/ping", VendorPingHandler(vendorSvc))
+		})
+
+		v1.Route("/apikeys", func(r chi.Router) {
+			r.Use(jwtAuth)
+			r.Get("/", ListAPIKeysHandler(apiKeySvc))
+			r.Post("/", APIKeyHandler(apiKeySvc))
+			r.Delete("/{id}", DeleteAPIKeyHandler(apiKeySvc))
 		})
 	})
 


### PR DESCRIPTION
## Summary
- add SQL queries and repository/service methods for listing and deleting API keys
- expose GET and DELETE /apikeys with JWT-only access
- document API key list and delete operations in OpenAPI spec

## Testing
- `go test ./...`
- `/tmp/sqlc generate`

------
https://chatgpt.com/codex/tasks/task_e_689dd54c02c0832db5e56eb8c08f9bbf