### PR TITLE
Expose key and last-used fields in API key list

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -160,10 +160,15 @@ components:
           format: int64
         label:
           type: string
+        key:
+          type: string
         active:
           type: boolean
         rate_rpm:
           type: integer
+        last_used_at:
+          type: string
+          format: date-time
         created_at:
           type: string
           format: date-time

--- a/internal/db/apikeys.sql.go
+++ b/internal/db/apikeys.sql.go
@@ -92,15 +92,17 @@ func (q *Queries) GetAPIKeyByHash(ctx context.Context, keyHash []byte) (GetAPIKe
 }
 
 const listAPIKeysByUser = `-- name: ListAPIKeysByUser :many
-SELECT id, label, active, rate_rpm, created_at FROM api_keys WHERE user_id = $1
+SELECT id, label, key_hash, active, rate_rpm, last_used_at, created_at FROM api_keys WHERE user_id = $1
 `
 
 type ListAPIKeysByUserRow struct {
-	ID        int64          `json:"id"`
-	Label     sql.NullString `json:"label"`
-	Active    bool           `json:"active"`
-	RateRpm   int32          `json:"rate_rpm"`
-	CreatedAt time.Time      `json:"created_at"`
+	ID         int64          `json:"id"`
+	Label      sql.NullString `json:"label"`
+	KeyHash    []byte         `json:"key_hash"`
+	Active     bool           `json:"active"`
+	RateRpm    int32          `json:"rate_rpm"`
+	LastUsedAt sql.NullTime   `json:"last_used_at"`
+	CreatedAt  time.Time      `json:"created_at"`
 }
 
 func (q *Queries) ListAPIKeysByUser(ctx context.Context, userID int64) ([]ListAPIKeysByUserRow, error) {
@@ -115,8 +117,10 @@ func (q *Queries) ListAPIKeysByUser(ctx context.Context, userID int64) ([]ListAP
 		if err := rows.Scan(
 			&i.ID,
 			&i.Label,
+			&i.KeyHash,
 			&i.Active,
 			&i.RateRpm,
+			&i.LastUsedAt,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/internal/db/queries/apikeys.sql
+++ b/internal/db/queries/apikeys.sql
@@ -7,7 +7,7 @@ VALUES ($1, $2, $3, $4)
 RETURNING id, user_id, label, active, rate_rpm, created_at;
 
 -- name: ListAPIKeysByUser :many
-SELECT id, label, active, rate_rpm, created_at FROM api_keys WHERE user_id = $1;
+SELECT id, label, key_hash, active, rate_rpm, last_used_at, created_at FROM api_keys WHERE user_id = $1;
 
 -- name: DeleteAPIKey :exec
 UPDATE api_keys SET active = FALSE WHERE user_id = $1 AND id = $2;


### PR DESCRIPTION
## Summary
- return API key hash and last-used timestamp in list API
- document new fields in OpenAPI spec

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689dde324b30832db6fc656f7597f3eb