### PR TITLE
feat: add inference models endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -70,6 +70,24 @@ paths:
       responses:
         '200':
           description: Vendor service is reachable
+  /inference/models:
+    get:
+      summary: List loaded models
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      responses:
+        '200':
+          description: A list of loaded models
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  models:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Model'
   /auth/sign-up:
     post:
       summary: Register a new account
@@ -199,6 +217,23 @@ components:
           $ref: '#/components/schemas/User'
         token:
           type: string
+    Model:
+      type: object
+      properties:
+        model_type:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        stage:
+          type: string
+        run_id:
+          type: string
+        signature_inputs:
+          type: array
+          items:
+            type: string
     Error:
       type: object
       properties:

--- a/internal/service/vendor.go
+++ b/internal/service/vendor.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"context"
+	"sort"
 
 	"github.com/jules-labs/go-api-prod-template/internal/clients"
 )
 
 type VendorService interface {
 	Ping(ctx context.Context) (string, error)
+	ListModels(ctx context.Context) ([]Model, error)
 }
 
 type vendorService struct {
@@ -22,4 +24,39 @@ func NewVendorService(client *clients.ThirdPartyClient) VendorService {
 
 func (s *vendorService) Ping(ctx context.Context) (string, error) {
 	return s.client.Ping(ctx)
+}
+
+// Model represents a single model returned by the vendor.
+type Model struct {
+	ModelType       string   `json:"model_type"`
+	Name            string   `json:"name"`
+	Version         string   `json:"version"`
+	Stage           string   `json:"stage"`
+	RunID           string   `json:"run_id"`
+	SignatureInputs []string `json:"signature_inputs"`
+}
+
+func (s *vendorService) ListModels(ctx context.Context) ([]Model, error) {
+	version, err := s.client.Version(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	models := make([]Model, 0, len(version.LoadedModels))
+	for modelType, m := range version.LoadedModels {
+		models = append(models, Model{
+			ModelType:       modelType,
+			Name:            m.Name,
+			Version:         m.Version,
+			Stage:           m.Stage,
+			RunID:           m.RunID,
+			SignatureInputs: m.SignatureInputs,
+		})
+	}
+
+	sort.Slice(models, func(i, j int) bool {
+		return models[i].ModelType < models[j].ModelType
+	})
+
+	return models, nil
 }

--- a/internal/service/vendor_test.go
+++ b/internal/service/vendor_test.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jules-labs/go-api-prod-template/internal/clients"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVendorService_ListModels(t *testing.T) {
+	response := `{"build_time":"dev","git_sha":"dev","mlflow_tracking_uri":"https://mlflow.fraudai.cloud","loaded_models":{"lightgbm":{"name":"FraudDetector-lightgbm","version":"1","stage":"None","run_id":"e3bc6f35cd3e4a2a977b62e2ffe5e181","signature_inputs":["transaction_id","amount","merchant_type","device_type"]},"xgboost":{"name":"FraudDetector-xgboost","version":"2","stage":"None","run_id":"76811460051f4229809b24d771a2ce2c","signature_inputs":["transaction_id","amount","merchant_type","device_type"]},"logreg":{"name":"FraudDetector-logistic_regression","version":"1","stage":"None","run_id":"121e6c15715c420b8f0b9139d75fd30d","signature_inputs":["transaction_id","amount","merchant_type","device_type"]}}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(response))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := clients.NewThirdPartyClient(server.URL, "", zerolog.Nop())
+	svc := NewVendorService(client)
+
+	models, err := svc.ListModels(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, models, 3)
+	assert.Equal(t, "lightgbm", models[0].ModelType)
+	assert.Equal(t, "FraudDetector-lightgbm", models[0].Name)
+}

--- a/internal/transport/http/handlers.go
+++ b/internal/transport/http/handlers.go
@@ -157,3 +157,14 @@ func VendorPingHandler(vendorSvc service.VendorService) http.HandlerFunc {
 		response.RespondWithJSON(w, http.StatusOK, map[string]string{"message": pong})
 	}
 }
+
+func ListModelsHandler(vendorSvc service.VendorService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		models, err := vendorSvc.ListModels(r.Context())
+		if err != nil {
+			response.RespondWithError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		response.RespondWithJSON(w, http.StatusOK, map[string]interface{}{"models": models})
+	}
+}

--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -74,6 +74,21 @@ func NewRouter(
 			r.Post("/", APIKeyHandler(apiKeySvc))
 			r.Delete("/{id}", DeleteAPIKeyHandler(apiKeySvc))
 		})
+
+		vendorAuth := app_middleware.AuthEither(
+			app_middleware.APIKeyAuth(apiKeyRepo, userRepo),
+			jwtAuth,
+		)
+
+		v1.Route("/vendor", func(r chi.Router) {
+			r.Use(vendorAuth)
+			r.Get("/ping", VendorPingHandler(vendorSvc))
+		})
+
+		v1.Route("/inference", func(r chi.Router) {
+			r.Use(vendorAuth)
+			r.Get("/models", ListModelsHandler(vendorSvc))
+		})
 	})
 
 	return r


### PR DESCRIPTION
## Summary
- expose `/v1/inference/models` to surface vendor model metadata
- transform vendor model map into array for client consumption
- document inference model listing in OpenAPI spec and add coverage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ddf755ef8832da57faadcec5acd93