### PR TITLE
Add prediction inference endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -88,6 +88,25 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Model'
+  /inference/predict:
+    post:
+      summary: Get fraud prediction
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PredictRequest'
+      responses:
+        '200':
+          description: Prediction result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PredictResponse'
   /auth/sign-up:
     post:
       summary: Register a new account
@@ -222,6 +241,46 @@ components:
           $ref: '#/components/schemas/User'
         token:
           type: string
+    PredictRequest:
+      type: object
+      properties:
+        model:
+          type: string
+        features:
+          type: object
+          additionalProperties: {}
+      required:
+        - model
+        - features
+    PredictResponse:
+      type: object
+      properties:
+        meta:
+          type: object
+          properties:
+            model_name:
+              type: string
+            run_id:
+              type: string
+            request_id:
+              type: string
+            timestamp:
+              type: string
+              format: date-time
+            latency_ms:
+              type: number
+        result:
+          type: object
+          properties:
+            prediction:
+              type: integer
+            score:
+              type: number
+            threshold:
+              type: number
+      required:
+        - meta
+        - result
     Model:
       type: object
       properties:

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -58,7 +58,7 @@ func main() {
 	profileSvc := service.NewProfileService(userRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo)
 	vendorClient := clients.NewThirdPartyClient(cfg.VendorBaseURL, cfg.VendorToken, logger)
-	vendorSvc := service.NewVendorService(vendorClient)
+	vendorSvc := service.NewVendorService(vendorClient, logger)
 	authSvc := service.NewAuthService(userRepo, jwtSecret, 24*time.Hour)
 
 	// Setup router

--- a/internal/transport/http/handlers.go
+++ b/internal/transport/http/handlers.go
@@ -204,3 +204,26 @@ func ListModelsHandler(vendorSvc service.VendorService) http.HandlerFunc {
 		response.RespondWithJSON(w, http.StatusOK, map[string]interface{}{"models": models})
 	}
 }
+
+func PredictHandler(vendorSvc service.VendorService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req service.PredictRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			response.RespondWithError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+
+		if err := validate.Struct(req); err != nil {
+			response.RespondWithError(w, http.StatusBadRequest, "validation failed: "+err.Error())
+			return
+		}
+
+		resp, err := vendorSvc.Predict(r.Context(), req)
+		if err != nil {
+			response.RespondWithError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+
+		response.RespondWithJSON(w, http.StatusOK, resp)
+	}
+}

--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -88,6 +88,7 @@ func NewRouter(
 		v1.Route("/inference", func(r chi.Router) {
 			r.Use(vendorAuth)
 			r.Get("/models", ListModelsHandler(vendorSvc))
+			r.Post("/predict", PredictHandler(vendorSvc))
 		})
 	})
 


### PR DESCRIPTION
## Summary
- add client and service layers to call third-party predict API and map response
- expose POST /v1/inference/predict for vendors
- document inference prediction endpoint in OpenAPI spec

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e1a000550832d917c62dd6c3c2a54