### PR TITLE
Mask API keys in listing response

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -199,6 +199,7 @@ components:
           type: string
         key:
           type: string
+          description: Masked API key with first 10 and last 6 characters visible
         active:
           type: boolean
         rate_rpm:

--- a/internal/transport/http/handlers_test.go
+++ b/internal/transport/http/handlers_test.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskAPIKey(t *testing.T) {
+	t.Run("mask long key", func(t *testing.T) {
+		key := "7061807972fbda86d89f899bc73124dcbee53a5a31b0e526cdd157110a6a9be3"
+		expected := key[:10] + strings.Repeat("*", len(key)-16) + key[len(key)-6:]
+		if got := maskAPIKey(key); got != expected {
+			t.Fatalf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("short key unchanged", func(t *testing.T) {
+		key := "123456789012345" // length 15
+		if got := maskAPIKey(key); got != key {
+			t.Fatalf("expected %q, got %q", key, got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- mask API keys in GET /v1/apikeys so only first 10 and last 6 characters are shown
- document masked key format in OpenAPI spec
- add unit test for masking utility

## Testing
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689e21747ca4832da05f3a393a0b3dcf