### PR TITLE
Delete API keys from database instead of deactivating

### DIFF
--- a/internal/db/apikeys.sql.go
+++ b/internal/db/apikeys.sql.go
@@ -53,7 +53,7 @@ func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (Cre
 }
 
 const deleteAPIKey = `-- name: DeleteAPIKey :exec
-UPDATE api_keys SET active = FALSE WHERE user_id = $1 AND id = $2
+DELETE FROM api_keys WHERE user_id = $1 AND id = $2
 `
 
 type DeleteAPIKeyParams struct {

--- a/internal/db/queries/apikeys.sql
+++ b/internal/db/queries/apikeys.sql
@@ -10,4 +10,4 @@ RETURNING id, user_id, label, active, rate_rpm, created_at;
 SELECT id, label, key_hash, active, rate_rpm, last_used_at, created_at FROM api_keys WHERE user_id = $1 AND active = TRUE;
 
 -- name: DeleteAPIKey :exec
-UPDATE api_keys SET active = FALSE WHERE user_id = $1 AND id = $2;
+DELETE FROM api_keys WHERE user_id = $1 AND id = $2;


### PR DESCRIPTION
## Summary
- remove API key rows when revoked

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e27728bb4832db3791875852f5c89