### PR TITLE
Add API key protected fraud prediction endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -92,8 +92,26 @@ paths:
     post:
       summary: Get fraud prediction
       security:
-        - ApiKeyAuth: []
         - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PredictRequest'
+      responses:
+        '200':
+          description: Prediction result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PredictResponse'
+
+  /fraud/predict:
+    post:
+      summary: Get fraud prediction
+      security:
+        - ApiKeyAuth: []
       requestBody:
         required: true
         content:

--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -87,8 +87,12 @@ func NewRouter(
 		})
 
 		v1.Route("/inference", func(r chi.Router) {
-			r.Use(vendorAuth)
-			r.Get("/models", ListModelsHandler(vendorSvc))
+			r.With(vendorAuth).Get("/models", ListModelsHandler(vendorSvc))
+			r.With(jwtAuth).Post("/predict", PredictHandler(vendorSvc, logRepo))
+		})
+
+		v1.Route("/fraud", func(r chi.Router) {
+			r.Use(app_middleware.APIKeyAuth(apiKeyRepo, userRepo))
 			r.Post("/predict", PredictHandler(vendorSvc, logRepo))
 		})
 	})


### PR DESCRIPTION
## Summary
- add new POST /v1/fraud/predict endpoint secured by API key authentication
- restrict existing /v1/inference/predict to bearer tokens and document both endpoints

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fc22f2c0c832db9c8f2cfad46777d