### PR TITLE
Enable Redis password authentication for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This project is a template for a production-ready web API written in Go. It incl
     export PG_DSN="postgres://user:password@localhost:5432/app?sslmode=disable"
     export JWT_SECRET_FILE="jwt.secret"
     export REDIS_ADDR="localhost:6379"
+    export REDIS_PASSWORD="password"
     ```
     Create the `jwt.secret` file:
     ```bash

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ pg_max_idle_conns: 25
 pg_conn_max_lifetime: 5m
 
 redis_addr: localhost:6379
+redis_password: password
 redis_db: 0
 
 jwt_secret_file: ./jwt.secret

--- a/deploy/stack.yml
+++ b/deploy/stack.yml
@@ -13,6 +13,8 @@ services:
     environment:
       - APP_ENV=production
       - PG_DSN=postgres://user:password@postgres:5432/app?sslmode=disable # Use a managed DB in prod
+      - REDIS_ADDR=redis:6379
+      - REDIS_PASSWORD=password
     secrets:
       - jwt_secret
     healthcheck:
@@ -38,6 +40,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    command: ["redis-server", "--requirepass", "password"]
     networks:
       - web # Should be on a private network with the API
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    command: ["redis-server", "--requirepass", "password"]
     ports:
       - "6379:6379"
 


### PR DESCRIPTION
## Summary
- add redis password configuration
- require password in dev docker-compose and stack deployment
- document REDIS_PASSWORD usage

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0814a2ab8832db9ebc22422a28377