### PR TITLE
refactor: pass JWT secret bytes to middleware

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -63,7 +63,7 @@ func main() {
 	authSvc := service.NewAuthService(userRepo, jwtSecret, 24*time.Hour)
 
 	// Setup router
-	router := httptransport.NewRouter(&cfg, dbConn, redisClient, userRepo, apiKeyRepo, logRepo, profileSvc, apiKeySvc, vendorSvc, authSvc, logger)
+	router := httptransport.NewRouter(&cfg, dbConn, redisClient, userRepo, apiKeyRepo, logRepo, profileSvc, apiKeySvc, vendorSvc, authSvc, jwtSecret, logger)
 
 	srv := &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", cfg.HTTPAddr, cfg.HTTPPort),

--- a/internal/transport/http/middleware/auth_jwt.go
+++ b/internal/transport/http/middleware/auth_jwt.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"context"
 	"net/http"
-	"os"
 	"strings"
 
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -11,7 +10,7 @@ import (
 	"github.com/jules-labs/go-api-prod-template/internal/transport/http/response"
 )
 
-func JWTAuth(jwtSecretFile string, userRepo repo.UserRepository) func(http.Handler) http.Handler {
+func JWTAuth(secret []byte, userRepo repo.UserRepository) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// If identity is already present, just pass through
@@ -35,12 +34,6 @@ func JWTAuth(jwtSecretFile string, userRepo repo.UserRepository) func(http.Handl
 				return
 			}
 			tokenString := parts[1]
-
-			secret, err := os.ReadFile(jwtSecretFile)
-			if err != nil {
-				response.RespondWithError(w, http.StatusInternalServerError, "could not read jwt secret")
-				return
-			}
 
 			token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 				if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {

--- a/internal/transport/http/middleware/auth_jwt_test.go
+++ b/internal/transport/http/middleware/auth_jwt_test.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/jules-labs/go-api-prod-template/internal/db"
+)
+
+// mockUserRepo implements repo.UserRepository for testing
+
+type mockUserRepo struct {
+	user db.GetUserByIDRow
+	err  error
+}
+
+func (m mockUserRepo) CreateUser(ctx context.Context, arg db.CreateUserParams) (db.CreateUserRow, error) {
+	return db.CreateUserRow{}, nil
+}
+
+func (m mockUserRepo) ListUsersPaged(ctx context.Context, arg db.ListUsersPagedParams) ([]db.ListUsersPagedRow, error) {
+	return nil, nil
+}
+
+func (m mockUserRepo) GetUserByID(ctx context.Context, id int64) (db.GetUserByIDRow, error) {
+	if m.err != nil {
+		return db.GetUserByIDRow{}, m.err
+	}
+	return m.user, nil
+}
+
+func (m mockUserRepo) GetUserByEmail(ctx context.Context, email string) (db.GetUserByEmailRow, error) {
+	return db.GetUserByEmailRow{}, nil
+}
+
+func (m mockUserRepo) GetUserByEmailForLogin(ctx context.Context, email string) (db.GetUserByEmailForLoginRow, error) {
+	return db.GetUserByEmailForLoginRow{}, nil
+}
+
+func TestJWTAuth(t *testing.T) {
+	secret := []byte("test-secret")
+	userRepo := mockUserRepo{user: db.GetUserByIDRow{ID: 1, Plan: "basic", CreatedAt: time.Now(), UpdatedAt: time.Now()}}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"user_id": 1})
+	tokenStr, err := token.SignedString(secret)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	t.Run("valid token attaches identity", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer "+tokenStr)
+
+		handlerCalled := false
+		JWTAuth(secret, userRepo)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handlerCalled = true
+			if id, ok := IdentityFrom(r.Context()); !ok || id.UserID != 1 {
+				t.Fatalf("identity not set")
+			}
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, req)
+
+		if !handlerCalled {
+			t.Fatalf("handler not called")
+		}
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer invalid")
+
+		JWTAuth(secret, userRepo)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("handler should not be called")
+		})).ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+		}
+	})
+}

--- a/internal/transport/http/router.go
+++ b/internal/transport/http/router.go
@@ -27,6 +27,7 @@ func NewRouter(
 	apiKeySvc service.APIKeyService,
 	vendorSvc service.VendorService,
 	authSvc service.AuthService,
+	jwtSecret []byte,
 	logger zerolog.Logger,
 ) http.Handler {
 	r := chi.NewRouter()
@@ -58,7 +59,7 @@ func NewRouter(
 	// API v1
 	r.Route("/v1", func(v1 chi.Router) {
 		// Auth
-		jwtAuth := app_middleware.JWTAuth(cfg.JWTSecretFile, userRepo)
+		jwtAuth := app_middleware.JWTAuth(jwtSecret, userRepo)
 		v1.Route("/auth", func(auth chi.Router) {
 			auth.Post("/sign-up", SignUpHandler(authSvc))
 			auth.Post("/sign-in", SignInHandler(authSvc))


### PR DESCRIPTION
## Summary
- update JWTAuth middleware to accept secret bytes instead of reading file per request
- pass JWT secret from main to router and middleware
- add tests for JWTAuth middleware

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a08a889104832db8a5b558ed960bd5