### PR TITLE
feat: cache API keys in Redis for faster auth

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -46,7 +46,7 @@ func main() {
 	// Setup repositories
 	queries := db.New(dbConn)
 	userRepo := repo.NewUserRepository(queries)
-	apiKeyRepo := repo.NewAPIKeyRepository(queries)
+	apiKeyRepo := repo.NewAPIKeyRepository(queries, redisClient, time.Hour)
 	logRepo := repo.NewInferenceLogRepository(queries)
 
 	// Read JWT secret

--- a/internal/repo/apikey_repo.go
+++ b/internal/repo/apikey_repo.go
@@ -3,10 +3,15 @@ package repo
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
+	redis "github.com/redis/go-redis/v9"
 
 	"github.com/jules-labs/go-api-prod-template/internal/db"
 )
@@ -19,17 +24,69 @@ type APIKeyRepository interface {
 }
 
 type postgresAPIKeyRepository struct {
-	q db.Querier
+	q           db.Querier
+	redisClient *redis.Client
+	ttl         time.Duration
 }
 
-func NewAPIKeyRepository(q db.Querier) APIKeyRepository {
+type cachedAPIKey struct {
+	ID      int64 `json:"id"`
+	UserID  int64 `json:"user_id"`
+	Active  bool  `json:"active"`
+	RateRpm int32 `json:"rate_rpm"`
+}
+
+func apiKeyCacheKey(hash []byte) string {
+	return fmt.Sprintf("apikey:%s", hex.EncodeToString(hash))
+}
+
+func apiKeyIDCacheKey(id int64) string {
+	return fmt.Sprintf("apikey_id:%d", id)
+}
+
+func NewAPIKeyRepository(q db.Querier, redisClient *redis.Client, ttl time.Duration) APIKeyRepository {
 	return &postgresAPIKeyRepository{
-		q: q,
+		q:           q,
+		redisClient: redisClient,
+		ttl:         ttl,
 	}
 }
 
 func (r *postgresAPIKeyRepository) GetAPIKeyByHash(ctx context.Context, keyHash []byte) (db.GetAPIKeyByHashRow, error) {
-	return r.q.GetAPIKeyByHash(ctx, keyHash)
+	if r.redisClient != nil {
+		cacheKey := apiKeyCacheKey(keyHash)
+		if data, err := r.redisClient.Get(ctx, cacheKey).Bytes(); err == nil {
+			var c cachedAPIKey
+			if json.Unmarshal(data, &c) == nil {
+				return db.GetAPIKeyByHashRow{
+					ID:      c.ID,
+					UserID:  c.UserID,
+					KeyHash: keyHash,
+					Active:  c.Active,
+					RateRpm: c.RateRpm,
+				}, nil
+			}
+		}
+	}
+
+	apiKey, err := r.q.GetAPIKeyByHash(ctx, keyHash)
+	if err != nil {
+		return apiKey, err
+	}
+
+	if r.redisClient != nil {
+		c := cachedAPIKey{
+			ID:      apiKey.ID,
+			UserID:  apiKey.UserID,
+			Active:  apiKey.Active,
+			RateRpm: apiKey.RateRpm,
+		}
+		if data, err := json.Marshal(c); err == nil {
+			_ = r.redisClient.Set(ctx, apiKeyCacheKey(keyHash), data, r.ttl).Err()
+			_ = r.redisClient.Set(ctx, apiKeyIDCacheKey(apiKey.ID), hex.EncodeToString(keyHash), r.ttl).Err()
+		}
+	}
+	return apiKey, nil
 }
 
 func (r *postgresAPIKeyRepository) CreateAPIKey(ctx context.Context, arg db.CreateAPIKeyParams) (db.CreateAPIKeyRow, error) {
@@ -40,6 +97,18 @@ func (r *postgresAPIKeyRepository) CreateAPIKey(ctx context.Context, arg db.Crea
 			return db.CreateAPIKeyRow{}, ErrAPIKeyLabelExists
 		}
 		return db.CreateAPIKeyRow{}, err
+	}
+	if r.redisClient != nil {
+		c := cachedAPIKey{
+			ID:      createdKey.ID,
+			UserID:  createdKey.UserID,
+			Active:  createdKey.Active,
+			RateRpm: createdKey.RateRpm,
+		}
+		if data, err := json.Marshal(c); err == nil {
+			_ = r.redisClient.Set(ctx, apiKeyCacheKey(arg.KeyHash), data, r.ttl).Err()
+			_ = r.redisClient.Set(ctx, apiKeyIDCacheKey(createdKey.ID), hex.EncodeToString(arg.KeyHash), r.ttl).Err()
+		}
 	}
 	return createdKey, nil
 }
@@ -53,7 +122,17 @@ func (r *postgresAPIKeyRepository) DeleteAPIKey(ctx context.Context, userID, key
 		UserID: userID,
 		ID:     keyID,
 	}
-	return r.q.DeleteAPIKey(ctx, params)
+	if err := r.q.DeleteAPIKey(ctx, params); err != nil {
+		return err
+	}
+	if r.redisClient != nil {
+		idKey := apiKeyIDCacheKey(keyID)
+		if hash, err := r.redisClient.Get(ctx, idKey).Result(); err == nil {
+			_ = r.redisClient.Del(ctx, idKey).Err()
+			_ = r.redisClient.Del(ctx, fmt.Sprintf("apikey:%s", hash)).Err()
+		}
+	}
+	return nil
 }
 
 // HashAPIKey creates a SHA256 hash of an API key.


### PR DESCRIPTION
## Summary
- cache API keys in Redis with TTL to minimize database lookups
- warm cache on creation and on DB fallback; map API key IDs to their hashes
- drop cache entries when API keys are deleted

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a08c83e0a0832d9069bcf004b5d351