### PR TITLE
Limit request body size and handle oversized payloads

### DIFF
--- a/internal/transport/http/handlers.go
+++ b/internal/transport/http/handlers.go
@@ -26,6 +26,8 @@ import (
 
 var validate = validator.New()
 
+const maxBodyBytes = 1 << 20 // 1MB
+
 func HealthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
@@ -119,7 +121,13 @@ func APIKeyHandler(apiKeySvc service.APIKeyService) http.HandlerFunc {
 		}
 
 		var req apiKeyRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBodyBytes))
+		if err := decoder.Decode(&req); err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				response.RespondWithError(w, http.StatusRequestEntityTooLarge, "payload too large")
+				return
+			}
 			response.RespondWithError(w, http.StatusBadRequest, "invalid request body")
 			return
 		}
@@ -293,9 +301,16 @@ func PredictHandler(vendorSvc service.VendorService, logRepo repo.InferenceLogRe
 
 		reqTime := time.Now()
 
-		bodyBytes, err := io.ReadAll(r.Body)
+		bodyReader := http.MaxBytesReader(w, r.Body, maxBodyBytes)
+		bodyBytes, err := io.ReadAll(bodyReader)
 		if err != nil {
 			respTime := time.Now()
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				saveInferenceLog(r.Context(), logRepo, identity, nil, nil, "payload too large", reqTime, respTime)
+				response.RespondWithError(w, http.StatusRequestEntityTooLarge, "payload too large")
+				return
+			}
 			saveInferenceLog(r.Context(), logRepo, identity, bodyBytes, nil, "invalid request body", reqTime, respTime)
 			response.RespondWithError(w, http.StatusBadRequest, "invalid request body")
 			return

--- a/internal/transport/http/handlers_test.go
+++ b/internal/transport/http/handlers_test.go
@@ -1,9 +1,53 @@
 package http
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/jules-labs/go-api-prod-template/internal/db"
+	app_middleware "github.com/jules-labs/go-api-prod-template/internal/transport/http/middleware"
 )
+
+type stubAPIKeyService struct{}
+
+func (s *stubAPIKeyService) CreateAPIKey(ctx context.Context, userID int64, label string, rateRPM int) (string, db.CreateAPIKeyRow, error) {
+	return "", db.CreateAPIKeyRow{}, nil
+}
+
+func (s *stubAPIKeyService) ListAPIKeys(ctx context.Context, userID int64) ([]db.ListAPIKeysByUserRow, error) {
+	return nil, nil
+}
+
+func (s *stubAPIKeyService) DeleteAPIKey(ctx context.Context, userID, keyID int64) error {
+	return nil
+}
+
+type stubUserRepo struct{}
+
+func (s *stubUserRepo) CreateUser(ctx context.Context, arg db.CreateUserParams) (db.CreateUserRow, error) {
+	return db.CreateUserRow{}, nil
+}
+
+func (s *stubUserRepo) ListUsersPaged(ctx context.Context, arg db.ListUsersPagedParams) ([]db.ListUsersPagedRow, error) {
+	return nil, nil
+}
+
+func (s *stubUserRepo) GetUserByID(ctx context.Context, id int64) (db.GetUserByIDRow, error) {
+	return db.GetUserByIDRow{ID: id, Plan: "basic"}, nil
+}
+
+func (s *stubUserRepo) GetUserByEmail(ctx context.Context, email string) (db.GetUserByEmailRow, error) {
+	return db.GetUserByEmailRow{}, nil
+}
+
+func (s *stubUserRepo) GetUserByEmailForLogin(ctx context.Context, email string) (db.GetUserByEmailForLoginRow, error) {
+	return db.GetUserByEmailForLoginRow{}, nil
+}
 
 func TestMaskAPIKey(t *testing.T) {
 	t.Run("mask long key", func(t *testing.T) {
@@ -20,4 +64,35 @@ func TestMaskAPIKey(t *testing.T) {
 			t.Fatalf("expected %q, got %q", key, got)
 		}
 	})
+}
+
+func TestAPIKeyHandler_PayloadTooLarge(t *testing.T) {
+	// prepare JWT secret file
+	secret := []byte("test-secret")
+	secretFile := t.TempDir() + "/jwt.secret"
+	if err := os.WriteFile(secretFile, secret, 0600); err != nil {
+		t.Fatalf("failed to write secret file: %v", err)
+	}
+
+	// create JWT token
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"user_id": 1})
+	tokenStr, err := token.SignedString(secret)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	// oversized JSON payload
+	payload := `{"label":"` + strings.Repeat("a", maxBodyBytes) + `"}`
+
+	req := httptest.NewRequest(http.MethodPost, "/apikeys", strings.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+
+	rr := httptest.NewRecorder()
+
+	handler := app_middleware.JWTAuth(secretFile, &stubUserRepo{})(APIKeyHandler(&stubAPIKeyService{}))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status %d, got %d", http.StatusRequestEntityTooLarge, rr.Code)
+	}
 }


### PR DESCRIPTION
## Summary
- cap HTTP request bodies at 1MB using `http.MaxBytesReader`
- return `413 Payload Too Large` when requests exceed the limit
- add test ensuring oversized API key payloads are rejected

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a08a8ded60832da09ecdfe9959858e