### PR TITLE
Run migrations before service startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ COPY --from=builder /app/server .
 COPY --from=builder /app/migrations ./migrations
 COPY --from=builder /app/api/openapi.yaml ./api/openapi.yaml
 COPY --from=builder /app/config.yaml ./config.yaml
+COPY --from=builder /go/bin/migrate /usr/local/bin/migrate
+COPY --from=builder /app/entrypoint.sh ./entrypoint.sh
 
 EXPOSE 8080
 
-CMD ["./server"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ curl http://localhost:8080/v1/profile-jwt \
 
 Configuration values are read from `config.yaml`. Secret values like `PG_DSN`, `REDIS_PASSWORD`, or `VENDOR_TOKEN` should be provided via environment variables or container secrets. See `internal/config/config.go` for all available options.
 
+## Deployment
+
+When the container starts, it automatically applies database migrations before launching the API server. The entrypoint runs:
+
+```sh
+migrate -path /root/migrations -database "$PG_DSN" up
+./server
+```
+
+Ensure the `PG_DSN` environment variable is set (for example via `deploy/stack.yml`) so the migrations can run successfully before the service begins accepting requests.
+
 ## Testing
 
 Run all tests:
@@ -114,6 +125,3 @@ Run all tests:
 make test
 ```
 This will run both unit and integration tests. Integration tests require Docker to be running.
-
-
-export PG_DSN="postgres://myuser:mypassword@localhost:5432/mydatabase?sslmode=disable"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+migrate -path /root/migrations -database "$PG_DSN" up
+exec ./server


### PR DESCRIPTION
## Summary
- copy migrate binary into final image and add entrypoint script to run migrations before launching server
- document automatic migrations and deployment requirements in README

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: identity not set)*


------
https://chatgpt.com/codex/tasks/task_e_68a0a5cf4cf0832d8c6e1614feb9078e