### PR TITLE
Restrict deploy workflow to main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: ["main"]
-  pull_request:
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Summary
- ensure deployment workflow only triggers on pushes to main by removing pull_request event

## Testing
- `make test` *(fails: TestJWTAuth/valid_token_attaches_identity)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c259f3f4832dae30535c31a18576