### PR TITLE
Fix migrate binary missing postgres driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 
 # tooling (optional, handy in CI)
 RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
-RUN go install github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /app/server ./cmd/api
 


### PR DESCRIPTION
## Summary
- build migrate CLI with postgres driver
- ensure Dockerfile ends with newline

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0d703951c832d8c891af3a9581563