### PR TITLE
chore: remove sqlc installation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN go mod download
 
 COPY . .
 
-# tooling (optional, handy in CI)
-RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+# tooling for migrations (optional, handy in CI)
 RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /app/server ./cmd/api


### PR DESCRIPTION
## Summary
- drop sqlc CLI install from Dockerfile
- keep migrate tooling for runtime migrations

## Testing
- `go test ./...` *(fails: no output; repository has no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef7b52ec832d9c7ade8572477942