### PR TITLE
chore: drop qemu setup from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,6 @@ jobs:
             echo "image_ref=${IMAGE_REF}"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR


### PR DESCRIPTION
## Summary
- remove docker/setup-qemu-action from deploy workflow
- retain docker/setup-buildx-action

## Testing
- `make test` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef76168c832db95f1255baeb5f21