### PR TITLE
Allow deleting API keys with existing inference logs

### DIFF
--- a/migrations/0005_update_inference_logs_apikey_fk.down.sql
+++ b/migrations/0005_update_inference_logs_apikey_fk.down.sql
@@ -1,0 +1,5 @@
+-- 0005_update_inference_logs_apikey_fk.down.sql
+ALTER TABLE inference_logs DROP CONSTRAINT IF EXISTS inference_logs_api_key_id_fkey;
+ALTER TABLE inference_logs
+    ADD CONSTRAINT inference_logs_api_key_id_fkey
+    FOREIGN KEY (api_key_id) REFERENCES api_keys(id);

--- a/migrations/0005_update_inference_logs_apikey_fk.up.sql
+++ b/migrations/0005_update_inference_logs_apikey_fk.up.sql
@@ -1,0 +1,5 @@
+-- 0005_update_inference_logs_apikey_fk.up.sql
+ALTER TABLE inference_logs DROP CONSTRAINT IF EXISTS inference_logs_api_key_id_fkey;
+ALTER TABLE inference_logs
+    ADD CONSTRAINT inference_logs_api_key_id_fkey
+    FOREIGN KEY (api_key_id) REFERENCES api_keys(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- allow deleting api keys that have existing inference logs by setting `ON DELETE SET NULL` on `inference_logs.api_key_id`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a1a03f8ba4832da89243e1e33bda7b